### PR TITLE
Migrate from QuickGraph to QuikGraph.

### DIFF
--- a/RxSpy.LiveView/GraphWindow.xaml
+++ b/RxSpy.LiveView/GraphWindow.xaml
@@ -3,7 +3,7 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:models="clr-namespace:RxSpy.Models"
         xmlns:graph="clr-namespace:RxSpy.ViewModels.Graphs"
-        xmlns:graphsharp="clr-namespace:GraphSharp.Controls;assembly=GraphSharp.Controls"
+        xmlns:graphshape="clr-namespace:GraphShape.Controls;assembly=GraphShape.Controls"
         xmlns:extbehaviour="clr-namespace:WPFExtensions.AttachedBehaviours;assembly=WPFExtensions"
         Title="GraphWindow" MinHeight="300" MinWidth="450" SizeToContent="WidthAndHeight">
     <Grid>
@@ -38,11 +38,11 @@
                 </DataTemplate.Triggers>
             </DataTemplate>
 
-            <Style TargetType="{x:Type graphsharp:VertexControl}">
+            <Style TargetType="{x:Type graphshape:VertexControl}">
                 <Setter Property="extbehaviour:DragBehaviour.IsDragEnabled" Value="False" />
                 <Setter Property="Template">
                     <Setter.Value>
-                        <ControlTemplate TargetType="{x:Type graphsharp:VertexControl}">
+                        <ControlTemplate TargetType="{x:Type graphshape:VertexControl}">
                             <ContentPresenter Content="{TemplateBinding Vertex}"/>
                         </ControlTemplate>
                     </Setter.Value>
@@ -53,7 +53,7 @@
         <Viewbox Margin="20" StretchDirection="DownOnly">
             <graph:ObservableGraphLayout 
                 x:Name="graphLayout" 
-                LayoutAlgorithmType="EfficientSugiyama"
+                LayoutAlgorithmType="Sugiyama"
                 IsAnimationEnabled="False"
                 CreationTransition="{x:Null}"
                 AsyncCompute="True"

--- a/RxSpy.LiveView/RxSpy.LiveView.csproj
+++ b/RxSpy.LiveView/RxSpy.LiveView.csproj
@@ -40,24 +40,15 @@
     <ApplicationIcon>Resources\rxspy.ico</ApplicationIcon>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="GraphSharp">
-      <HintPath>..\packages\GraphSharp.1.1.0.0\lib\net40\GraphSharp.dll</HintPath>
+    <Reference Include="GraphShape">
+      <HintPath>..\packages\GraphShape.1.1.0\lib\net45\GraphShape.dll</HintPath>
     </Reference>
-    <Reference Include="GraphSharp.Controls">
-      <HintPath>..\packages\GraphSharp.1.1.0.0\lib\net40\GraphSharp.Controls.dll</HintPath>
+    <Reference Include="GraphShape.Controls">
+      <HintPath>..\packages\GraphShape.Controls.1.1.0\lib\net45\GraphShape.Controls.dll</HintPath>
     </Reference>
     <Reference Include="PresentationFramework.Aero2" />
-    <Reference Include="QuickGraph">
-      <HintPath>..\packages\QuickGraph.3.6.61119.7\lib\net4\QuickGraph.dll</HintPath>
-    </Reference>
-    <Reference Include="QuickGraph.Data">
-      <HintPath>..\packages\QuickGraph.3.6.61119.7\lib\net4\QuickGraph.Data.dll</HintPath>
-    </Reference>
-    <Reference Include="QuickGraph.Graphviz">
-      <HintPath>..\packages\QuickGraph.3.6.61119.7\lib\net4\QuickGraph.Graphviz.dll</HintPath>
-    </Reference>
-    <Reference Include="QuickGraph.Serialization">
-      <HintPath>..\packages\QuickGraph.3.6.61119.7\lib\net4\QuickGraph.Serialization.dll</HintPath>
+    <Reference Include="QuikGraph">
+      <HintPath>..\packages\QuikGraph.2.2.0\lib\net45\QuikGraph.dll</HintPath>
     </Reference>
     <Reference Include="ReactiveUI, Version=6.0.6.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/RxSpy.LiveView/RxSpy.LiveView.csproj
+++ b/RxSpy.LiveView/RxSpy.LiveView.csproj
@@ -48,7 +48,7 @@
     </Reference>
     <Reference Include="PresentationFramework.Aero2" />
     <Reference Include="QuikGraph">
-      <HintPath>..\packages\QuikGraph.2.2.0\lib\net45\QuikGraph.dll</HintPath>
+      <HintPath>..\packages\QuikGraph.2.3.0\lib\net45\QuikGraph.dll</HintPath>
     </Reference>
     <Reference Include="ReactiveUI, Version=6.0.6.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/RxSpy.LiveView/ViewModels/Graphs/ObservableGraph.cs
+++ b/RxSpy.LiveView/ViewModels/Graphs/ObservableGraph.cs
@@ -3,8 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
-using GraphSharp;
-using QuickGraph;
+using QuikGraph;
 using RxSpy.Models;
 
 namespace RxSpy.ViewModels.Graphs

--- a/RxSpy.LiveView/ViewModels/Graphs/ObservableGraphLayout.cs
+++ b/RxSpy.LiveView/ViewModels/Graphs/ObservableGraphLayout.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
-using GraphSharp.Controls;
+using GraphShape.Controls;
 using RxSpy.Models;
 
 namespace RxSpy.ViewModels.Graphs

--- a/RxSpy.LiveView/ViewModels/Graphs/ObserveableEdge.cs
+++ b/RxSpy.LiveView/ViewModels/Graphs/ObserveableEdge.cs
@@ -4,7 +4,7 @@ using System.Diagnostics;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
-using QuickGraph;
+using QuikGraph;
 using RxSpy.Models;
 
 namespace RxSpy.ViewModels.Graphs

--- a/RxSpy.LiveView/packages.config
+++ b/RxSpy.LiveView/packages.config
@@ -2,7 +2,7 @@
 <packages>
   <package id="GraphShape" version="1.1.0" targetFramework="net45" />
   <package id="GraphShape.Controls" version="1.1.0" targetFramework="net45" />
-  <package id="QuikGraph" version="2.2.0" targetFramework="net45" />
+  <package id="QuikGraph" version="2.3.0" targetFramework="net45" />
   <package id="reactiveui" version="6.0.6" targetFramework="net45" />
   <package id="reactiveui-blend" version="6.0.6" targetFramework="net45" />
   <package id="reactiveui-core" version="6.0.6" targetFramework="net45" />

--- a/RxSpy.LiveView/packages.config
+++ b/RxSpy.LiveView/packages.config
@@ -1,7 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="GraphSharp" version="1.1.0.0" targetFramework="net45" />
-  <package id="QuickGraph" version="3.6.61119.7" targetFramework="net45" />
+  <package id="GraphShape" version="1.1.0" targetFramework="net45" />
+  <package id="GraphShape.Controls" version="1.1.0" targetFramework="net45" />
+  <package id="QuikGraph" version="2.2.0" targetFramework="net45" />
   <package id="reactiveui" version="6.0.6" targetFramework="net45" />
   <package id="reactiveui-blend" version="6.0.6" targetFramework="net45" />
   <package id="reactiveui-core" version="6.0.6" targetFramework="net45" />


### PR DESCRIPTION
Hello,

I updated the quite old QuickGraph and GraphSharp dependencies to respectively QuikGraph and GraphShape.

Those libraries are using modern C# development workflow, have been ported to .NET Core with a wider support in term of targets.
And finally they come with a huge set of unit tests that has helped to debug and fix a lot of issues in both libraries.

Here are the links to both libraries:
- [QuikGraph](https://github.com/KeRNeLith/QuikGraph)
- [GraphShape](https://github.com/KeRNeLith/GraphShape)